### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/yach/e04b05b6-eac3-435b-88aa-9858f83c22fe/38dbfb7a-5ff5-4039-85c2-763cc47cbce2/_apis/work/boardbadge/bb7ec41c-3db9-42b3-89e8-59d09b672909)](https://dev.azure.com/yach/e04b05b6-eac3-435b-88aa-9858f83c22fe/_boards/board/t/38dbfb7a-5ff5-4039-85c2-763cc47cbce2/Microsoft.RequirementCategory)
 # python3
 A repository to hold python3 scripts


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/yach/e04b05b6-eac3-435b-88aa-9858f83c22fe/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.